### PR TITLE
execcmd manager init/start task: Decoupled Linux and Windows code files

### DIFF
--- a/agent/engine/execcmd/manager.go
+++ b/agent/engine/execcmd/manager.go
@@ -27,9 +27,6 @@ import (
 )
 
 const (
-	hostExecDepsDir = "/var/lib/ecs/deps/execute-command"
-	HostBinDir      = hostExecDepsDir + "/bin"
-
 	ExecuteCommandAgentName    = ecs.ManagedAgentNameExecuteCommandAgent
 	defaultStartRetryTimeout   = time.Minute * 10
 	defaultRetryMinDelay       = time.Second * 1

--- a/agent/engine/execcmd/manager_init_task_windows.go
+++ b/agent/engine/execcmd/manager_init_task_windows.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows
+// +build windows
 
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 //
@@ -12,14 +12,11 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
+
 package execcmd
 
 import (
-	"context"
-
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
-	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
-	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
@@ -27,21 +24,10 @@ const (
 	// ECSAgentExecLogDir here is used used while cleaning up exec logs when task exits.
 	// When this path is empty, nothing is cleaned up for unsupported platforms.
 	ECSAgentExecLogDir = ""
-	HostBinDir         = ""
 )
 
-// Note: exec cmd agent is a linux/windows feature, thus implemented here as a no-op.
-func (m *manager) RestartAgentIfStopped(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) (RestartStatus, error) {
-	return NotRestarted, nil
-}
-
-// Note: exec cmd agent is a linux/windows feature, thus implemented here as a no-op.
-func (m *manager) StartAgent(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) error {
-	return nil
-}
-
 // InitializeContainer adds the necessary bind mounts in order for the ExecCommandAgent to run properly in the container
-// Note: exec cmd agent is a linux/windows feature, thus implemented here as a no-op.
+// Note: exec cmd agent is a linux feature, thus implemented here as a no-op.
 func (m *manager) InitializeContainer(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
 	return nil
 }

--- a/agent/engine/execcmd/manager_linux.go
+++ b/agent/engine/execcmd/manager_linux.go
@@ -1,0 +1,21 @@
+// +build linux
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+const (
+	hostExecDepsDir = "/var/lib/ecs/deps/execute-command"
+	HostBinDir      = hostExecDepsDir + "/bin"
+)

--- a/agent/engine/execcmd/manager_start_windows.go
+++ b/agent/engine/execcmd/manager_start_windows.go
@@ -1,0 +1,19 @@
+package execcmd
+
+import (
+	"context"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apitask "github.com/aws/amazon-ecs-agent/agent/api/task"
+	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+)
+
+// Note: exec cmd agent is a linux/windows feature, thus implemented here as a no-op.
+func (m *manager) RestartAgentIfStopped(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) (RestartStatus, error) {
+	return NotRestarted, nil
+}
+
+// Note: exec cmd agent is a linux/windows feature, thus implemented here as a no-op.
+func (m *manager) StartAgent(ctx context.Context, client dockerapi.DockerClient, task *apitask.Task, container *apicontainer.Container, containerId string) error {
+	return nil
+}

--- a/agent/engine/execcmd/manager_windows.go
+++ b/agent/engine/execcmd/manager_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+import (
+	"path/filepath"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
+)
+
+var (
+	hostExecDepsDir = filepath.Join(config.AmazonECSProgramFiles, "managed-agents", "execute-command")
+	HostBinDir      = filepath.Join(hostExecDepsDir, "bin")
+)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
