### PR TITLE
agent_capability: Decoupled Linux/Windows Execcmd checks

### DIFF
--- a/agent/app/agent_capability.go
+++ b/agent/app/agent_capability.go
@@ -69,7 +69,6 @@ const (
 	capabilityEnvFilesS3                        = "env-files.s3"
 	capabilityFSxWindowsFileServer              = "fsxWindowsFileServer"
 	capabilityExec                              = "execute-command"
-	capabilityDepsRootDir                       = "/managed-agents"
 	capabilityExecBinRelativePath               = "bin"
 	capabilityExecConfigRelativePath            = "config"
 	capabilityExecCertsRelativePath             = "certs"
@@ -97,11 +96,6 @@ var (
 		capabilityFullTaskSync,
 		// ecs agent version 1.39.0 supports bulk loading env vars through environmentFiles in S3
 		capabilityEnvFilesS3,
-	}
-	capabilityExecRequiredBinaries = []string{
-		"amazon-ssm-agent",
-		"ssm-agent-worker",
-		"ssm-session-worker",
 	}
 	capabilityExecRequiredCerts = []string{
 		"tls-ca-bundle.pem",

--- a/agent/app/agent_capability_unix.go
+++ b/agent/app/agent_capability_unix.go
@@ -30,11 +30,20 @@ import (
 )
 
 const (
-	AVX         = "avx"
-	AVX2        = "avx2"
-	SSE41       = "sse4_1"
-	SSE42       = "sse4_2"
-	CpuInfoPath = "/proc/cpuinfo"
+	AVX                   = "avx"
+	AVX2                  = "avx2"
+	SSE41                 = "sse4_1"
+	SSE42                 = "sse4_2"
+	CpuInfoPath           = "/proc/cpuinfo"
+	capabilityDepsRootDir = "/managed-agents"
+)
+
+var (
+	capabilityExecRequiredBinaries = []string{
+		"amazon-ssm-agent",
+		"ssm-agent-worker",
+		"ssm-session-worker",
+	}
 )
 
 func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {

--- a/agent/app/agent_capability_unspecified.go
+++ b/agent/app/agent_capability_unspecified.go
@@ -26,6 +26,14 @@ import (
 	"github.com/cihub/seelog"
 )
 
+const (
+	capabilityDepsRootDir = ""
+)
+
+var (
+	capabilityExecRequiredBinaries = []string{}
+)
+
 func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {
 	// "local" is default docker driver
 	capabilities = appendNameOnlyAttribute(capabilities, attributePrefix+capabilityDockerPluginInfix+volume.DockerLocalVolumeDriver)

--- a/agent/app/agent_capability_windows.go
+++ b/agent/app/agent_capability_windows.go
@@ -16,8 +16,20 @@
 package app
 
 import (
+	"path/filepath"
+
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	"github.com/aws/amazon-ecs-agent/agent/ecs_client/model/ecs"
 	"github.com/aws/amazon-ecs-agent/agent/taskresource/volume"
+)
+
+var (
+	capabilityDepsRootDir          = filepath.Join(config.AmazonECSProgramFiles, "managed-agents")
+	capabilityExecRequiredBinaries = []string{
+		"amazon-ssm-agent.exe",
+		"ssm-agent-worker.exe",
+		"ssm-session-worker.exe",
+	}
 )
 
 func (agent *ecsAgent) appendVolumeDriverCapabilities(capabilities []*ecs.Attribute) []*ecs.Attribute {

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -65,6 +65,11 @@ const (
 	adminSid = "S-1-5-32-544"
 )
 
+var (
+	envProgramFiles       = utils.DefaultIfBlank(os.Getenv("ProgramFiles"), `C:\Program Files`)
+	AmazonECSProgramFiles = filepath.Join(envProgramFiles, "Amazon", "ECS")
+)
+
 // DefaultConfig returns the default configuration for Windows
 func DefaultConfig() Config {
 	programData := utils.DefaultIfBlank(os.Getenv("ProgramData"), `C:\ProgramData`)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
