### PR TITLE
execcmd manager init task: Windows functionality added

### DIFF
--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -66,9 +66,14 @@ const (
 )
 
 var (
-	envProgramFiles       = utils.DefaultIfBlank(os.Getenv("ProgramFiles"), `C:\Program Files`)
-	AmazonProgramFiles    = filepath.Join(envProgramFiles, "Amazon")
+	envProgramFiles = utils.DefaultIfBlank(os.Getenv("ProgramFiles"), `C:\Program Files`)
+	envProgramData  = utils.DefaultIfBlank(os.Getenv("ProgramData"), `C:\ProgramData`)
+
+	AmazonProgramFiles = filepath.Join(envProgramFiles, "Amazon")
+	AmazonProgramData  = filepath.Join(envProgramData, "Amazon")
+
 	AmazonECSProgramFiles = filepath.Join(envProgramFiles, "Amazon", "ECS")
+	AmazonECSProgramData  = filepath.Join(AmazonProgramData, "ECS")
 )
 
 // DefaultConfig returns the default configuration for Windows

--- a/agent/engine/execcmd/manager_init_task.go
+++ b/agent/engine/execcmd/manager_init_task.go
@@ -1,0 +1,148 @@
+// +build linux windows
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package execcmd
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	"github.com/pborman/uuid"
+)
+
+const (
+	namelessContainerPrefix = "nameless-container-"
+
+	// filePerm is the permission for the exec agent config file.
+	filePerm            = 0644
+	defaultSessionLimit = 2
+
+	containerConfigFileName = "amazon-ssm-agent.json"
+	ContainerConfigDirName  = "config"
+
+	ExecAgentLogConfigFileName = "seelog.xml"
+)
+
+var (
+	errExecCommandManagedAgentNotFound = fmt.Errorf("managed agent not found (%s)", ExecuteCommandAgentName)
+)
+
+func (m *manager) getLatestVersionedHostBinDir() (string, error) {
+	versions, err := retrieveAgentVersions(ecsAgentDepsBinDir)
+	if err != nil {
+		return "", err
+	}
+	sort.Sort(sort.Reverse(byAgentVersion(versions)))
+
+	var latest string
+	for _, v := range versions {
+		vStr := v.String()
+		ecsAgentDepsVersionedBinDir := filepath.Join(ecsAgentDepsBinDir, vStr)
+		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentBinName)) {
+			continue // try falling back to the previous version
+		}
+		// TODO: [ecs-exec] This requirement will be removed for SSM agent V2
+		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentWorkerBinName)) {
+			continue // try falling back to the previous version
+		}
+		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SessionWorkerBinName)) {
+			continue // try falling back to the previous version
+		}
+		latest = filepath.Join(m.hostBinDir, vStr)
+		break
+	}
+	if latest == "" {
+		return "", fmt.Errorf("no valid versions were found in %s", m.hostBinDir)
+	}
+	return latest, nil
+}
+
+func getReadOnlyBindMountMapping(hostDir, containerDir string) string {
+	return getBindMountMapping(hostDir, containerDir) + ":ro"
+}
+
+func getBindMountMapping(hostDir, containerDir string) string {
+	return hostDir + ":" + containerDir
+}
+
+var newUUID = uuid.New
+
+func fileSystemSafeContainerName(c *apicontainer.Container) string {
+	// Trim leading hyphens since they're not valid directory names
+	cn := strings.TrimLeft(c.Name, "-")
+	if cn == "" {
+		// Fallback name in the extreme case that we end up with an empty string after trimming all leading hyphens.
+		return namelessContainerPrefix + newUUID()
+	}
+	return cn
+}
+
+func getSessionWorkersLimit(ma apicontainer.ManagedAgent) int {
+	// TODO [ecs-exec] : verify that returning the default session limit (2) is ok in case of any errors, misconfiguration
+	limit := defaultSessionLimit
+	if ma.Properties == nil { // This means ACS didn't send the limit
+		return limit
+	}
+	limitStr, ok := ma.Properties["sessionLimit"]
+	if !ok { // This also means ACS didn't send the limit
+		return limit
+	}
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil { // This means ACS send a limit that can't be converted to an int
+		return limit
+	}
+	if limit <= 0 {
+		limit = defaultSessionLimit
+	}
+	return limit
+}
+
+var removeAll = os.RemoveAll
+
+var getFileContent = readFileContent
+
+func readFileContent(filePath string) ([]byte, error) {
+	return ioutil.ReadFile(filePath)
+}
+
+func getExecAgentConfigHash(config string) string {
+	hash := sha256.New()
+	hash.Write([]byte(config))
+	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
+}
+
+var osStat = os.Stat
+
+func fileExists(path string) bool {
+	if fi, err := osStat(path); err == nil {
+		return !fi.IsDir()
+	}
+	return false
+}
+
+func isDir(path string) bool {
+	if fi, err := osStat(path); err == nil {
+		return fi.IsDir()
+	}
+	return false
+}

--- a/agent/engine/execcmd/manager_init_task_linux.go
+++ b/agent/engine/execcmd/manager_init_task_linux.go
@@ -15,26 +15,18 @@
 package execcmd
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
-	"sort"
-	"strconv"
 	"strings"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
-	"github.com/pborman/uuid"
 
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
 	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
 )
 
 const (
-	namelessContainerPrefix = "nameless-container-"
-
 	ecsAgentExecDepsDir = "/managed-agents/execute-command"
 
 	// ecsAgentDepsBinDir is the directory where ECS Agent will read versions of SSM agent
@@ -42,10 +34,6 @@ const (
 	ecsAgentDepsCertsDir = ecsAgentExecDepsDir + "/certs"
 
 	ContainerDepsDirPrefix = "/ecs-execute-command-"
-
-	// filePerm is the permission for the exec agent config file.
-	filePerm            = 0644
-	defaultSessionLimit = 2
 
 	SSMAgentBinName       = "amazon-ssm-agent"
 	SSMAgentWorkerBinName = "ssm-agent-worker"
@@ -58,16 +46,13 @@ const (
 	HostCertFile            = "/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem"
 	ContainerCertFileSuffix = "certs/amazon-ssm-agent.crt"
 
-	containerConfigFileName   = "amazon-ssm-agent.json"
-	ContainerConfigDirName    = "config"
 	ContainerConfigFileSuffix = "configuration/" + containerConfigFileName
 
 	// ECSAgentExecConfigDir is the directory where ECS Agent will write the ExecAgent config files to
 	ECSAgentExecConfigDir = ecsAgentExecDepsDir + "/" + ContainerConfigDirName
 	// HostExecConfigDir is the dir where ExecAgents Config files will live
-	HostExecConfigDir          = hostExecDepsDir + "/" + ContainerConfigDirName
-	ExecAgentLogConfigFileName = "seelog.xml"
-	ContainerLogConfigFile     = "configuration/" + ExecAgentLogConfigFileName
+	HostExecConfigDir      = hostExecDepsDir + "/" + ContainerConfigDirName
+	ContainerLogConfigFile = "configuration/" + ExecAgentLogConfigFileName
 )
 
 var (
@@ -107,9 +92,8 @@ var (
 </formats>
 </seelog>`
 	// TODO: [ecs-exec] seelog config needs to be implemented following a similar approach to ss, config
-	execAgentConfigFileNameTemplate    = `amazon-ssm-agent-%s.json`
-	logConfigFileNameTemplate          = `seelog-%s.xml`
-	errExecCommandManagedAgentNotFound = fmt.Errorf("managed agent not found (%s)", ExecuteCommandAgentName)
+	execAgentConfigFileNameTemplate = `amazon-ssm-agent-%s.json`
+	logConfigFileNameTemplate       = `seelog-%s.xml`
 )
 
 // InitializeContainer adds the necessary bind mounts in order for the ExecCommandAgent to run properly in the container
@@ -192,76 +176,6 @@ func (m *manager) InitializeContainer(taskId string, container *apicontainer.Con
 	return nil
 }
 
-func (m *manager) getLatestVersionedHostBinDir() (string, error) {
-	versions, err := retrieveAgentVersions(ecsAgentDepsBinDir)
-	if err != nil {
-		return "", err
-	}
-	sort.Sort(sort.Reverse(byAgentVersion(versions)))
-
-	var latest string
-	for _, v := range versions {
-		vStr := v.String()
-		ecsAgentDepsVersionedBinDir := filepath.Join(ecsAgentDepsBinDir, vStr)
-		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentBinName)) {
-			continue // try falling back to the previous version
-		}
-		// TODO: [ecs-exec] This requirement will be removed for SSM agent V2
-		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SSMAgentWorkerBinName)) {
-			continue // try falling back to the previous version
-		}
-		if !fileExists(filepath.Join(ecsAgentDepsVersionedBinDir, SessionWorkerBinName)) {
-			continue // try falling back to the previous version
-		}
-		latest = filepath.Join(m.hostBinDir, vStr)
-		break
-	}
-	if latest == "" {
-		return "", fmt.Errorf("no valid versions were found in %s", m.hostBinDir)
-	}
-	return latest, nil
-}
-
-func getReadOnlyBindMountMapping(hostDir, containerDir string) string {
-	return getBindMountMapping(hostDir, containerDir) + ":ro"
-}
-
-func getBindMountMapping(hostDir, containerDir string) string {
-	return hostDir + ":" + containerDir
-}
-
-var newUUID = uuid.New
-
-func fileSystemSafeContainerName(c *apicontainer.Container) string {
-	// Trim leading hyphens since they're not valid directory names
-	cn := strings.TrimLeft(c.Name, "-")
-	if cn == "" {
-		// Fallback name in the extreme case that we end up with an empty string after trimming all leading hyphens.
-		return namelessContainerPrefix + newUUID()
-	}
-	return cn
-}
-
-func getSessionWorkersLimit(ma apicontainer.ManagedAgent) int {
-	// TODO [ecs-exec] : verify that returning the default session limit (2) is ok in case of any errors, misconfiguration
-	limit := defaultSessionLimit
-	if ma.Properties == nil { // This means ACS didn't send the limit
-		return limit
-	}
-	limitStr, ok := ma.Properties["sessionLimit"]
-	if !ok { // This also means ACS didn't send the limit
-		return limit
-	}
-	limit, err := strconv.Atoi(limitStr)
-	if err != nil { // This means ACS send a limit that can't be converted to an int
-		return limit
-	}
-	if limit <= 0 {
-		limit = defaultSessionLimit
-	}
-	return limit
-}
-
 var GetExecAgentLogConfigFile = getAgentLogConfigFile
 
 func getAgentLogConfigFile() (string, error) {
@@ -285,8 +199,6 @@ func getAgentLogConfigFile() (string, error) {
 	return logConfigFileName, nil
 }
 
-var removeAll = os.RemoveAll
-
 func validConfigExists(configFilePath, expectedHash string) bool {
 	config, err := getFileContent(configFilePath)
 	if err != nil {
@@ -294,12 +206,6 @@ func validConfigExists(configFilePath, expectedHash string) bool {
 	}
 	hash := getExecAgentConfigHash(string(config))
 	return strings.Compare(expectedHash, hash) == 0
-}
-
-var getFileContent = readFileContent
-
-func readFileContent(filePath string) ([]byte, error) {
-	return ioutil.ReadFile(filePath)
 }
 
 var GetExecAgentConfigFileName = getAgentConfigFileName
@@ -324,28 +230,6 @@ func getAgentConfigFileName(sessionLimit int) (string, error) {
 		return "", err
 	}
 	return configFileName, nil
-}
-
-func getExecAgentConfigHash(config string) string {
-	hash := sha256.New()
-	hash.Write([]byte(config))
-	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
-}
-
-var osStat = os.Stat
-
-func fileExists(path string) bool {
-	if fi, err := osStat(path); err == nil {
-		return !fi.IsDir()
-	}
-	return false
-}
-
-func isDir(path string) bool {
-	if fi, err := osStat(path); err == nil {
-		return fi.IsDir()
-	}
-	return false
 }
 
 var createNewExecAgentConfigFile = createNewConfigFile

--- a/agent/engine/execcmd/manager_init_task_windows.go
+++ b/agent/engine/execcmd/manager_init_task_windows.go
@@ -16,18 +16,209 @@
 package execcmd
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	apicontainer "github.com/aws/amazon-ecs-agent/agent/api/container"
+	apicontainerstatus "github.com/aws/amazon-ecs-agent/agent/api/container/status"
+	"github.com/aws/amazon-ecs-agent/agent/config"
 	dockercontainer "github.com/docker/docker/api/types/container"
 )
 
 const (
-	// ECSAgentExecLogDir here is used used while cleaning up exec logs when task exits.
-	// When this path is empty, nothing is cleaned up for unsupported platforms.
-	ECSAgentExecLogDir = ""
+	folderPerm = 0755
 )
 
-// InitializeContainer adds the necessary bind mounts in order for the ExecCommandAgent to run properly in the container
-// Note: exec cmd agent is a linux feature, thus implemented here as a no-op.
-func (m *manager) InitializeContainer(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) error {
+var (
+	ecsAgentExecDepsDir = config.AmazonECSProgramFiles + "\\managed-agents\\execute-command"
+
+	// ecsAgentDepsBinDir is the directory where ECS Agent will read versions of SSM agent
+	ecsAgentDepsBinDir    = ecsAgentExecDepsDir + "\\bin"
+	ecsAgentDepsConfigDir = ecsAgentExecDepsDir + "\\config"
+
+	containerDepsFolder = "C:\\Program Files\\Amazon\\SSM"
+
+	SSMAgentBinName       = "amazon-ssm-agent.exe"
+	SSMAgentWorkerBinName = "ssm-agent-worker.exe"
+	SessionWorkerBinName  = "ssm-session-worker.exe"
+
+	HostLogDir      = config.AmazonECSProgramData + "\\exec"
+	ContainerLogDir = config.AmazonProgramData + "\\SSM"
+
+	SSMPluginDir = "C:\\Program Files\\Amazon\\SSM\\Plugins"
+	// since ecs agent windows is not running in a container, the agent and host log dirs are the same
+	ECSAgentExecLogDir = config.AmazonECSProgramData + "\\exec"
+
+	// ECSAgentExecConfigDir is the directory where ECS Agent will write the ExecAgent config files to
+	ECSAgentExecConfigDir = ecsAgentExecDepsDir + "\\" + ContainerConfigDirName
+	// HostExecConfigDir is the dir where ExecAgents Config files will live
+	HostExecConfigDir = hostExecDepsDir + "\\" + ContainerConfigDirName
+
+	configFiles = []string{
+		"amazon-ssm-agent.json",
+		"seelog.xml",
+	}
+
+	execAgentConfigTemplate = `{
+"Mgs": {
+	"Region": "",
+	"Endpoint": "",
+	"StopTimeoutMillis": 20000,
+	"SessionWorkersLimit": %d
+},
+"Agent": {
+	"Region": "",
+	"OrchestrationRootDir": "",
+	"ContainerMode": true
+}
+}`
+
+	execAgentLogConfigTemplate = `<!--amazon-ssm-agent uses seelog logging -->
+<!--Seelog has github wiki pages, which contain detailed how-tos references: https://github.com/cihub/seelog/wiki -->
+<!--Seelog examples can be found here: https://github.com/cihub/seelog-examples -->
+<seelog type="adaptive" mininterval="2000000" maxinterval="100000000" critmsgcount="500" minlevel="info">
+    <exceptions>
+        <exception filepattern="test*" minlevel="error"/>
+    </exceptions>
+    <outputs formatid="fmtinfo">
+        <console formatid="fmtinfo"/>
+        <rollingfile type="size" filename="C:\ProgramData\Amazon\SSM\Logs\amazon-ssm-agent.log" maxsize="30000000" maxrolls="5"/>
+        <filter levels="error,critical" formatid="fmterror">
+            <rollingfile type="size" filename="C:\ProgramData\Amazon\SSM\Logs\errors.log" maxsize="10000000" maxrolls="5"/>
+        </filter>
+    </outputs>
+    <formats>
+        <format id="fmterror" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+        <format id="fmtdebug" format="%Date %Time %LEVEL [%FuncShort @ %File.%Line] %Msg%n"/>
+        <format id="fmtinfo" format="%Date %Time %LEVEL %Msg%n"/>
+    </formats>
+</seelog>`
+)
+
+func (m *manager) InitializeContainer(taskId string, container *apicontainer.Container, hostConfig *dockercontainer.HostConfig) (rErr error) {
+	defer func() {
+		if rErr != nil {
+			container.UpdateManagedAgentByName(ExecuteCommandAgentName, apicontainer.ManagedAgentState{
+				InitFailed: true,
+				Status:     apicontainerstatus.ManagedAgentStopped,
+				Reason:     rErr.Error(),
+			})
+		}
+	}()
+
+	ma, ok := container.GetManagedAgentByName(ExecuteCommandAgentName)
+	if !ok {
+		return errExecCommandManagedAgentNotFound
+	}
+
+	cn := fileSystemSafeContainerName(container)
+
+	// In windows host mounts are not created automatically, so need to create
+	rErr = os.MkdirAll(filepath.Join(HostLogDir, taskId, cn), folderPerm)
+	if rErr != nil {
+		return rErr
+	}
+
+	configDirHash, rErr := getAgentConfigDir(getSessionWorkersLimit(ma))
+	if rErr != nil {
+		rErr = fmt.Errorf("could not generate ExecAgent Config dir: %v", rErr)
+		return rErr
+	}
+	uuid := newUUID()
+
+	latestBinVersionDir, rErr := m.getLatestVersionedHostBinDir()
+	if rErr != nil {
+		return rErr
+	}
+
+	// Add ssm binary mount
+	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
+		latestBinVersionDir,
+		containerDepsFolder))
+
+	// Add ssm configuration dir mount
+	hostConfig.Binds = append(hostConfig.Binds, getReadOnlyBindMountMapping(
+		filepath.Join(ecsAgentDepsConfigDir, configDirHash),
+		filepath.Join(containerDepsFolder, "configuration")))
+
+	// Add ssm log bind mount
+	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(
+		filepath.Join(HostLogDir, taskId, cn),
+		ContainerLogDir))
+
+	// add ssm plugin bind mount (needed for execcmd windows)
+	hostConfig.Binds = append(hostConfig.Binds, getBindMountMapping(
+		SSMPluginDir,
+		SSMPluginDir))
+
+	container.UpdateManagedAgentByName(ExecuteCommandAgentName, apicontainer.ManagedAgentState{
+		ID: uuid,
+	})
+
 	return nil
+}
+
+// Retrieves cached config dir, creates new one if needed
+func getAgentConfigDir(sessionLimit int) (string, error) {
+	agentConfig := fmt.Sprintf(execAgentConfigTemplate, sessionLimit)
+	hash := getExecAgentConfigHash(agentConfig + execAgentLogConfigTemplate)
+	// check if cached config dir exists already
+	configDirFilePath := filepath.Join(ECSAgentExecConfigDir, hash)
+	if isDir(configDirFilePath) && validConfigDirExists(configDirFilePath, hash) {
+		return hash, nil
+	}
+	// check if config file is a file; if true, remove it
+	if fileExists(configDirFilePath) {
+		if err := removeAll(configDirFilePath); err != nil {
+			return "", err
+		}
+	}
+	// create new config dir
+	if err := createNewExecAgentConfigDir(agentConfig, configDirFilePath, hash); err != nil {
+		return "", err
+	}
+	return hash, nil
+}
+
+var createNewExecAgentConfigDir = createNewConfigDir
+
+func createNewConfigDir(agentConfig, configDirPath, hash string) error {
+	// make top level config directory
+	err := os.MkdirAll(filepath.Join(ecsAgentDepsConfigDir, hash), folderPerm)
+	if err != nil {
+		return err
+	}
+
+	// make individual config files
+	agentConfigFilePath := filepath.Join(configDirPath, containerConfigFileName)
+	err = ioutil.WriteFile(agentConfigFilePath, []byte(agentConfig), filePerm)
+	if err != nil {
+		return err
+	}
+
+	logConfigFilePath := filepath.Join(configDirPath, ExecAgentLogConfigFileName)
+	err = ioutil.WriteFile(logConfigFilePath, []byte(execAgentLogConfigTemplate), filePerm)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validConfigDirExists(configDirFilePath, expectedHash string) bool {
+	// check that each config file exists and create a hash of their summed contents
+	contentSum := ""
+	for _, element := range configFiles {
+		config, err := getFileContent(filepath.Join(configDirFilePath, element))
+		if err != nil {
+			return false
+		}
+		contentSum += string(config)
+	}
+
+	hash := getExecAgentConfigHash(contentSum)
+	return strings.Compare(expectedHash, hash) == 0
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
